### PR TITLE
Make EnvBench multiplatform!

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -34,3 +34,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/jetbrains-research/envbench-${{ matrix.language }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -14,17 +14,23 @@ jobs:
       matrix:
         language: [python, jvm]
     steps:
-      - uses: actions/checkout@v2
+      - name: Check out main branch
+        uses: actions/checkout@v4
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push
-        uses: docker/build-push-action@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and Push
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: dockerfiles/${{ matrix.language }}.Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/jetbrains-research/envbench-${{ matrix.language }}:latest

--- a/dockerfiles/jvm.Dockerfile
+++ b/dockerfiles/jvm.Dockerfile
@@ -45,8 +45,8 @@ ENV PATH="$SDKMAN_DIR/bin:$SDKMAN_DIR/candidates/maven/current/bin:$SDKMAN_DIR/c
 # Initialize SDKMAN and install default tools
 RUN bash -c "source $SDKMAN_DIR/bin/sdkman-init.sh && \
     sdk install java 11.0.20-tem && \
-    sdk install maven && \
-    sdk install gradle && \
+    sdk install maven 3.9.10 && \
+    sdk install gradle 8.14.2 && \
     sdk use java 11.0.20-tem"
 
 RUN pip install --no-cache-dir search-and-replace

--- a/dockerfiles/python.Dockerfile
+++ b/dockerfiles/python.Dockerfile
@@ -47,8 +47,9 @@ RUN git clone https://github.com/pyenv/pyenv.git $PYENV_ROOT \
 
 # Install miniconda
 ENV CONDA_DIR=/opt/conda
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
-    /bin/bash ~/miniconda.sh -b -p /opt/conda
+RUN wget --quiet https://github.com/conda-forge/miniforge/releases/download/25.3.0-3/Miniforge3-25.3.0-3-Linux-$(uname -m).sh -O /tmp/miniconda.sh \
+    && /bin/bash /tmp/miniconda.sh -b -p /opt/conda \
+    && rm /tmp/miniconda.sh
 
 # Put conda in path so we can use conda activate
 ENV PATH=$CONDA_DIR/bin:$PATH


### PR DESCRIPTION
Greetings agents! As you may already know, I'm currently working on another project that closely intersects with this one. For this reason, I've been looking at EnvBench and trying to run its Docker images locally. That's when I discovered that EnvBench can only be built for `linux/amd64`, meaning that I would not be able to run it on my Apple M2 Max. 😢

But that need not be! The goal of this PR is to make the EnvBench Docker images multi-platform. This involves changes to the images themselves, as well as the GitHub Actions CI used to build them.

**The current problems with the build can be summed up as follows:**

1. `py.Dockerfile` currently always downloads the `x86_64` installer for `conda`, regardless of what architecture you are currently building on. Trying to build the image on ARM chips yields the following error:

	```
	[+] Building 4.4s (8/17)                                                                                                                                                                    docker:desktop-linux
	 => [internal] load build definition from python.Dockerfile                                                                                                                                                 0.0s
	 => => transferring dockerfile: 2.60kB                                                                                                                                                                      0.0s
	 => [internal] load metadata for docker.io/library/ubuntu:22.04                                                                                                                                             1.1s
	 => [auth] library/ubuntu:pull token for registry-1.docker.io                                                                                                                                               0.0s
	 => [internal] load .dockerignore                                                                                                                                                                           0.1s
	 => => transferring context: 2B                                                                                                                                                                             0.0s
	 => [ 1/13] FROM docker.io/library/ubuntu:22.04@sha256:01a3ee0b5e413cefaaffc6abe68c9c37879ae3cced56a8e088b1649e5b269eee                                                                                     0.0s
	 => => resolve docker.io/library/ubuntu:22.04@sha256:01a3ee0b5e413cefaaffc6abe68c9c37879ae3cced56a8e088b1649e5b269eee                                                                                       0.0s
	 => CACHED [ 2/13] RUN adduser --force-badname --system --no-create-home _apt     && apt-get update -yqq     && apt-get install -yqq         python3         python3-pip         curl         wget          0.0s
	 => CACHED [ 3/13] RUN git clone https://github.com/pyenv/pyenv.git /root/.pyenv     && /root/.pyenv/bin/pyenv install 3.13.1     && /root/.pyenv/bin/pyenv install 3.12.0     && /root/.pyenv/bin/pyenv i  0.0s
	 => ERROR [ 4/13] RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh &&     /bin/bash ~/miniconda.sh -b -p /opt/conda                                 3.0s
	------                                                                                                                                                                                                           
	 > [ 4/13] RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh &&     /bin/bash ~/miniconda.sh -b -p /opt/conda:                                            
	2.277 PREFIX=/opt/conda                                                                                                                                                                                          
	2.805 Unpacking payload ...                                                                                                                                                                                      
	2.829 rosetta error: failed to open elf at /lib64/ld-linux-x86-64.so.2
	2.829  /root/miniconda.sh: line 333:    43 Exit 141                extract_range "${boundary1}" "${boundary2}"
	2.830         44 Trace/breakpoint trap   | CONDA_QUIET="$BATCH" "$CONDA_EXEC" constructor --extract-tarball --prefix "$PREFIX"
	------
	python.Dockerfile:50
	--------------------
	  49 |     ENV CONDA_DIR=/opt/conda
	  50 | >>> RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
	  51 | >>>     /bin/bash ~/miniconda.sh -b -p /opt/conda
	  52 |     
	--------------------
	ERROR: failed to solve: process "/bin/sh -c wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh &&     /bin/bash ~/miniconda.sh -b -p /opt/conda" did not complete successfully: exit code: 133
	
	View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/2fet229agraspjtapxz0b9vet
	```

2. `jvm.Dockerfile` currently fails when attempting to install Maven `3.9.9`. Not sure why it's doing that (since there is a more recent version), but it would appear that there are incompatibilities with the image-specific Java installation:

	```
	[+] Building 24.7s (7/13)                                                                                                                                                                   docker:desktop-linux
	 => [internal] load build definition from jvm.Dockerfile                                                                                                                                                    0.0s
	 => => transferring dockerfile: 3.03kB                                                                                                                                                                      0.0s
	 => [internal] load metadata for docker.io/library/ubuntu:22.04                                                                                                                                             0.5s
	 => [internal] load .dockerignore                                                                                                                                                                           0.0s
	 => => transferring context: 2B                                                                                                                                                                             0.0s
	 => [ 1/10] FROM docker.io/library/ubuntu:22.04@sha256:01a3ee0b5e413cefaaffc6abe68c9c37879ae3cced56a8e088b1649e5b269eee                                                                                     0.0s
	 => => resolve docker.io/library/ubuntu:22.04@sha256:01a3ee0b5e413cefaaffc6abe68c9c37879ae3cced56a8e088b1649e5b269eee                                                                                       0.0s
	 => CACHED [ 2/10] RUN apt-get update &&     apt-get install -yqq --no-install-recommends     curl     zip     unzip     git     bash     ca-certificates     jq     xmlstarlet     python3     python3-pi  0.0s
	 => CACHED [ 3/10] RUN curl -s "https://get.sdkman.io" | bash                                                                                                                                               0.0s
	 => ERROR [ 4/10] RUN bash -c "source /root/.sdkman/bin/sdkman-init.sh &&     sdk install java 11.0.20-tem &&     sdk install maven &&     sdk install gradle &&     sdk use java 11.0.20-tem"             24.2s
	------                                                                                                                                                                                                           
	 > [ 4/10] RUN bash -c "source /root/.sdkman/bin/sdkman-init.sh &&     sdk install java 11.0.20-tem &&     sdk install maven &&     sdk install gradle &&     sdk use java 11.0.20-tem":                         
	0.856                                                                                                                                                                                                            
	0.856 Downloading: java 11.0.20-tem                                                                                                                                                                              
	0.856                                                                                                                                                                                                            
	0.856 In progress...
	0.856 
	######################################################################## 100.0%     
	9.605 
	9.605 Repackaging Java 11.0.20-tem...
	18.30 
	18.30 Done repackaging...
	20.10 
	20.10 Installing: java 11.0.20-tem
	21.96 Done installing!
	21.96 
	21.96 
	21.96 Setting java 11.0.20-tem as default.
	23.11 
	23.11 Downloading: maven 3.9.9
	23.11 
	23.11 In progress...
	23.11 
	######################################################################## 100.0%     
	23.96 
	23.96 Stop! The archive was corrupt and has been removed! Please try installing again.
	------
	jvm.Dockerfile:46
	--------------------
	  45 |     # Initialize SDKMAN and install default tools
	  46 | >>> RUN bash -c "source $SDKMAN_DIR/bin/sdkman-init.sh && \
	  47 | >>>     sdk install java 11.0.20-tem && \
	  48 | >>>     sdk install maven && \
	  49 | >>>     sdk install gradle && \
	  50 | >>>     sdk use java 11.0.20-tem"
	  51 |     
	--------------------
	ERROR: failed to solve: process "/bin/sh -c bash -c \"source $SDKMAN_DIR/bin/sdkman-init.sh &&     sdk install java 11.0.20-tem &&     sdk install maven &&     sdk install gradle &&     sdk use java 11.0.20-tem\"" did not complete successfully: exit code: 1
	
	View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/zmufmo3wy0ll953fyoyjjeo6f
	```

**Here's what this PR does to address these problems:**

1. I changed the `conda` installation method to take the architecture into account. This is actually how they do it in their own [miniconda image](https://github.com/conda-forge/miniforge-images/blob/master/ubuntu/Dockerfile) (albeit with extra steps). While one could copy the installation from their image:

	```
	COPY --from=condaforge/miniforge3:25.3.0-3 /opt/conda /opt/conda
	```
	
	I reckon the manual installation method is generally safer.

2. I pinned `maven` and `gradle` to their respective latest versions. The error does not seem to appear anymore. This probably warrants some additional investigation.
3. I made the Docker builds in CI use the `platform` parameter to build for both `amd64` and `arm64`. This involved adding a couple of additional steps to the job like the Buildx and QEMU setup. This also required bumping some of the other actions to more recent versions.
4. I also added build caching to make the CI faster. Probably will not be noticeable the first time around, but will be on the following runs.