### PR TITLE
Make Python image builds faster!

### DIFF
--- a/dockerfiles/python.Dockerfile
+++ b/dockerfiles/python.Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.04
 
 # Set environment variables
 ENV PYENV_ROOT="/root/.pyenv" \
-    PATH="/root/.pyenv/bin:/root/.pyenv/shims:/root/.pyenv/versions/3.12.0/bin:$PATH" \
+    PATH="/root/.pyenv/bin:/root/.pyenv/shims:/root/.pyenv/versions/3.12.11/bin:$PATH" \
     DEBIAN_FRONTEND=noninteractive
 
 # Install system dependencies and additional tools


### PR DESCRIPTION
While it's great that EnvBench can now be run cross-platform (#1), the build times for the image have noticeably increased. The total duration of [the latest GitHub Actions build](https://github.com/JetBrains-Research/EnvBench/actions/runs/15616267025) for said image spans **3 hours**. Most of this time is spent compiling the five Python versions within the emulated architecture stage of the multi-platform build.

This PR seeks to address this by "seeding" `pyenv` through binaries downloaded from [`python-build-standalone`](https://github.com/astral-sh/python-build-standalone). In summary, rather than building all the different Python versions ourselves, we download the pre-built binaries and then just point `pyenv` to them. This should lead to considerable speedups in multi-platform image builds. Although I can't say how long this will take in CI, my local builds have dropped from more than 30 minutes to less than 5.