### PR TITLE
Create `python` symlink if it does not exist

### DIFF
--- a/dockerfiles/python.Dockerfile
+++ b/dockerfiles/python.Dockerfile
@@ -57,6 +57,8 @@ RUN set -eu; \
         tar -xzf "/tmp/$VERSION.tar.gz" \
             -C "$PYENV_ROOT/versions/$VERSION" \
             --strip-components=1; \
+        ln -frs "$PYENV_ROOT/versions/$VERSION/bin/python${VERSION%.*}" \
+                "$PYENV_ROOT/versions/$VERSION/bin/python"; \
         rm "/tmp/$VERSION.tar.gz"; \
     done < /tmp/python-versions.csv; \
     pyenv rehash


### PR DESCRIPTION
The recent switch to `python-build-standalone` has one limitation: some of the Python releases don't come with the `python` symlink. While using `python` instead of `python3` is generally not advisable, there are scripts in the dataset that rely on it. Affected versions seem to be everything after 3.10. This PR introduces a step to the image build to force-create a symlink, thus ensuring it will always be there.