### PR TITLE
Bring back `miniconda`!

### DIFF
--- a/dockerfiles/python.Dockerfile
+++ b/dockerfiles/python.Dockerfile
@@ -65,7 +65,7 @@ RUN set -eu; \
 
 # Install miniconda
 ENV CONDA_DIR=/opt/conda
-RUN wget --quiet https://github.com/conda-forge/miniforge/releases/download/25.3.0-3/Miniforge3-25.3.0-3-Linux-$(uname -m).sh -O /tmp/miniconda.sh \
+RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py313_25.3.1-1-Linux-$(uname -m).sh -O /tmp/miniconda.sh \
     && /bin/bash /tmp/miniconda.sh -b -p /opt/conda \
     && rm /tmp/miniconda.sh
 


### PR DESCRIPTION
I recently introduced multiplatform support (#1), and one of the main fixes was the hard-coded usage of `x86_64` in the Conda installation script URL. While changing it, I also changed the download source from [Miniconda repository](https://repo.anaconda.com/miniconda) to [`miniforge` GitHub releases](https://github.com/conda-forge/miniforge/releases). What I was not aware of is that these two have subtle differences:

1. For one, `miniforge`-installed Conda is the same as Miniconda-installed conda, _except_ that it uses the `conda-forge` channel (and only the `conda-forge` channel) as the default channel. Miniconda uses the official `anaconda` channel by default. These details are sourced from [this](https://stackoverflow.com/questions/60532678) StackOverflow question.
2. By default, the latest release of `miniforge`-installed Conda comes with _Python 3.12.10_, while Miniconda comes with _Python 3.13.2_. By extension, this means that the _system_ Python installation will be different!

In the interest of keeping reproducibility, I've opted to revert this change.